### PR TITLE
Add ShapeNet profile and taxonomy utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 `pcdset` converts loose point cloud files into well organised datasets.
 The first built in profile targets the [PCN dataset](https://github.com/wentaoyuan/pcn).
+A second profile converts data into a [ShapeNet](https://shapenet.org/) style
+layout.
 
 ## Installation
 
@@ -47,6 +49,50 @@ pcdset convert --profile pcn --input <input> --out <out> \
 
 ```bash
 pcdset validate --profile pcn --root D:/datasets/PCN_custom
+```
+
+## ShapeNet profile
+
+The ``shapenet`` profile converts arbitrary point clouds into a directory
+structure compatible with ShapeNet style datasets.
+
+### Example manifest
+
+```bash
+pcdset example-manifest --profile shapenet -o manifest.csv
+```
+
+### Convert using a manifest
+
+```bash
+pcdset convert \
+  --profile shapenet \
+  --input D:/raw_points \
+  --manifest D:/raw_points/manifest.csv \
+  --out D:/datasets/ShapeNet_custom \
+  --points-n 2048 \
+  --normalize unit --center --fps --dedup \
+  --file-ext ply --basename points \
+  --taxonomy-out taxonomy.csv \
+  --to-lmdb --lmdb-max-gb 32 \
+  --workers 8
+```
+
+### Convert by directory inference
+
+```
+<input>/<category>/<model_id>/*.(ply|pcd|txt|csv|npz)
+```
+
+```bash
+pcdset convert --profile shapenet --input <input> --out <out> \
+               --points-n 2048 --normalize unit --center
+```
+
+### Validate
+
+```bash
+pcdset validate --profile shapenet --root D:/datasets/ShapeNet_custom
 ```
 
 ## Quick start (Windows PowerShell)

--- a/pcdset/__init__.py
+++ b/pcdset/__init__.py
@@ -4,6 +4,8 @@ Provides package metadata and convenience imports.
 """
 from __future__ import annotations
 
-__all__ = ["__version__"]
+from .profiles.shapenet import ShapeNetProfile
+
+__all__ = ["__version__", "ShapeNetProfile"]
 
 __version__ = "0.1.0"

--- a/pcdset/io/writer_ply.py
+++ b/pcdset/io/writer_ply.py
@@ -1,4 +1,11 @@
-"""PLY writer."""
+"""Point cloud writers for simple formats.
+
+This module primarily exposes :func:`write_ply` which historically only
+handled the PLY format.  For the ShapeNet profile we also need support for
+``.pcd`` and ``.npz`` outputs while keeping the same function signature.
+The implementation therefore inspects the target file extension and selects
+an appropriate backend.
+"""
 from __future__ import annotations
 
 from pathlib import Path
@@ -6,12 +13,12 @@ from typing import Dict, Optional
 
 import numpy as np
 
-try:  # pragma: no cover
+try:  # pragma: no cover - optional dependency
     import open3d as o3d
 except Exception:  # pragma: no cover
     o3d = None  # type: ignore
 
-try:  # pragma: no cover
+try:  # pragma: no cover - optional dependency
     from plyfile import PlyData, PlyElement
 except Exception:  # pragma: no cover
     PlyData = None  # type: ignore
@@ -20,14 +27,41 @@ from ..utils.logging import logger
 
 
 def write_ply(path: Path, points: np.ndarray, attrs: Optional[Dict[str, np.ndarray]] = None) -> None:
-    """Write points to ``path`` in PLY format."""
+    """Write points to ``path``.
+
+    The output format is determined by the file extension:
+
+    ``.ply`` or ``.pcd``
+        Written via :mod:`open3d` when available and falling back to
+        :mod:`plyfile` for PLY.  Only the XYZ coordinates are persisted unless
+        ``attrs`` is provided, in which case additional columns are written
+        for the PLY backend.
+
+    ``.npz``
+        Stored using :func:`numpy.savez` with the key ``"points"`` and any
+        optional attributes.
+    """
+
     path.parent.mkdir(parents=True, exist_ok=True)
+    ext = path.suffix.lower()
+
+    if ext == ".npz":
+        data: Dict[str, np.ndarray] = {"points": points.astype(np.float32)}
+        if attrs:
+            data.update(attrs)
+        np.savez(path, **data)
+        return
+
     if o3d is not None:
         pc = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(points))
+        # open3d selects the format based on the extension (ply or pcd).
         o3d.io.write_point_cloud(str(path), pc, write_ascii=True)
         return
-    if PlyData is None:
-        raise RuntimeError("plyfile library required to write PLY when open3d is missing")
+
+    if PlyData is None or ext != ".ply":
+        raise RuntimeError("open3d required to write this file format")
+
+    # Fallback PLY writer using plyfile
     dtype = [("x", "f4"), ("y", "f4"), ("z", "f4")]
     if attrs:
         for key, arr in attrs.items():

--- a/pcdset/main.py
+++ b/pcdset/main.py
@@ -1,4 +1,7 @@
-"""Main entry point for the :mod:`pcdset` command line tool."""
+"""Main entry point for the :mod:`pcdset` command line tool.
+
+The CLI exposes conversion profiles such as ``pcn`` and ``shapenet``.
+"""
 from __future__ import annotations
 
 from .cli import app

--- a/pcdset/profiles/__init__.py
+++ b/pcdset/profiles/__init__.py
@@ -1,7 +1,8 @@
 """Profile implementations for :mod:`pcdset`."""
 from __future__ import annotations
 
-__all__ = ["PCNProfile", "BaseProfile"]
+__all__ = ["PCNProfile", "ShapeNetProfile", "BaseProfile"]
 
 from .base import BaseProfile
 from .pcn import PCNProfile
+from .shapenet import ShapeNetProfile

--- a/pcdset/profiles/shapenet.py
+++ b/pcdset/profiles/shapenet.py
@@ -1,0 +1,202 @@
+"""ShapeNet profile implementation."""
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Set
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import numpy as np
+from tqdm import tqdm
+
+from ..io import read_points, write_ply, LMDBWriter
+from ..ops import (
+    center as op_center,
+    unit_sphere,
+    bbox_scale,
+    random_sample,
+    farthest_point_sample,
+    voxel_downsample,
+    dedup as op_dedup,
+)
+from ..utils.logging import logger
+from ..utils.manifest import Entry
+from ..utils import taxonomy
+from .base import BaseProfile
+
+_SAN = re.compile(r"[^-_.0-9a-zA-Z]+")
+
+
+def _sanitize(text: str) -> str:
+    """Sanitize category/model identifiers."""
+
+    return _SAN.sub("_", text)
+
+
+@dataclass
+class ShapeNetProfile(BaseProfile):
+    """Convert arbitrary point clouds into a ShapeNet style layout."""
+
+    name: str = "shapenet"
+    points_n: int = 2048
+    file_ext: str = "ply"
+    basename: str = "points"
+    normalize: str = "none"
+    center: bool = False
+    dedup: bool = False
+    fps: bool = False
+    voxel: float = 0.0
+    save_meta: bool = False
+    save_attrs: bool = False
+    to_lmdb: bool = False
+    lmdb_max_gb: int = 64
+    overwrite: bool = False
+    workers: int = 8
+    taxonomy_out: Optional[Path] = None
+
+    def prepare(self, points: np.ndarray, role: str, _args: Optional[dict] = None) -> np.ndarray:  # noqa: D401 - see base class
+        if self.voxel > 0:
+            points = voxel_downsample(points, self.voxel)
+        if self.dedup:
+            points = op_dedup(points)
+        if self.center:
+            points = op_center(points)
+        if self.normalize == "unit":
+            points = unit_sphere(points)
+        elif self.normalize == "bbox":
+            points = bbox_scale(points)
+        n = self.points_n
+        if self.fps:
+            sampled = farthest_point_sample(points, min(len(points), n))
+        else:
+            sampled = random_sample(points, min(len(points), n))
+        if len(sampled) < n:
+            extra = random_sample(points, n - len(sampled))
+            sampled = np.concatenate([sampled, extra], axis=0)
+            logger.warning("Point cloud had fewer than %d points, sampling with replacement", n)
+        return sampled.astype(np.float32)
+
+    # Internal worker processing
+    def _process(
+        self,
+        entry: Entry,
+        out_dir: Path,
+        lmdb: Optional[LMDBWriter],
+        failed: List[Entry],
+        splits: Dict[str, Set[str]],
+        cats: Set[str],
+    ) -> None:
+        try:
+            points, attrs = read_points(entry.path)
+            pts = self.prepare(points, entry.role)
+            cat = _sanitize(entry.category)
+            model = _sanitize(entry.model_id)
+            rel = f"{cat}/{model}"
+            splits.setdefault(entry.split, set()).add(rel)
+            cats.add(cat)
+            model_dir = out_dir / entry.split / cat / model
+            model_dir.mkdir(parents=True, exist_ok=True)
+            file_name = f"{self.basename}_{self.points_n}.{self.file_ext}"
+            file_path = model_dir / file_name
+            write_ply(file_path, pts)
+            if self.save_attrs and attrs:
+                np.savez(file_path.with_suffix(".npz"), **attrs)
+            if self.save_meta:
+                meta = {"source": str(entry.path)}
+                with (model_dir / "meta.json").open("w", encoding="utf-8") as fh:
+                    json.dump(meta, fh, indent=2)
+            if lmdb is not None:
+                lmdb.put(f"object/{rel}", pts)
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.error("Failed to process %s: %s", entry.path, exc)
+            failed.append(entry)
+
+    def convert(self, entries: Iterable[Entry], out_dir: Path) -> None:  # noqa: D401 - see base class
+        out_dir.mkdir(parents=True, exist_ok=True)
+        lmdb_writer: Optional[LMDBWriter] = None
+        if self.to_lmdb:
+            lmdb_writer = LMDBWriter(out_dir / "lmdb", map_size_gb=self.lmdb_max_gb, overwrite=self.overwrite)
+        failed: List[Entry] = []
+        splits: Dict[str, Set[str]] = {}
+        cats: Set[str] = set()
+        entries_list = list(entries)
+        with ThreadPoolExecutor(max_workers=self.workers) as ex:
+            futures = [
+                ex.submit(self._process, e, out_dir, lmdb_writer, failed, splits, cats) for e in entries_list
+            ]
+            for _ in tqdm(as_completed(futures), total=len(futures), desc="convert"):
+                pass
+        if lmdb_writer is not None:
+            meta = {"profile": self.name, "timestamp": time.time()}
+            lmdb_writer.close(meta)
+        split_dir = out_dir / "splits"
+        for split, items in splits.items():
+            if not items:
+                continue
+            file = split_dir / f"{split}.txt"
+            file.parent.mkdir(parents=True, exist_ok=True)
+            with file.open("w", encoding="utf-8") as fh:
+                for rel in sorted(items):
+                    fh.write(rel + "\n")
+        if self.taxonomy_out and not self.taxonomy_out.exists():
+            tax = taxonomy.build_taxonomy(cats)
+            taxonomy.save_taxonomy(tax, self.taxonomy_out)
+        if failed:
+            import csv
+            with (out_dir / "_failed.csv").open("w", newline="", encoding="utf-8") as fh:
+                writer = csv.writer(fh)
+                writer.writerow(["path", "role", "category", "model_id", "view_id", "split"])
+                for e in failed:
+                    writer.writerow([e.path, e.role, e.category, e.model_id, e.view_id or "", e.split])
+            logger.warning("%d files failed. See _failed.csv", len(failed))
+
+    def validate_structure(self, root: Path) -> None:  # noqa: D401 - see base class
+        missing = 0
+        data_paths: Set[str] = set()
+        for split in ("train", "val", "test"):
+            split_dir = root / split
+            if not split_dir.exists():
+                continue
+            for cat_dir in split_dir.iterdir():
+                if not cat_dir.is_dir():
+                    continue
+                for model_dir in cat_dir.iterdir():
+                    if not model_dir.is_dir():
+                        continue
+                    data_file = model_dir / f"{self.basename}_{self.points_n}.{self.file_ext}"
+                    rel = f"{cat_dir.name}/{model_dir.name}"
+                    data_paths.add(rel)
+                    if not data_file.exists():
+                        logger.error("Missing point cloud for %s", data_file)
+                        missing += 1
+        splits_dir = root / "splits"
+        for split_file in splits_dir.glob("*.txt"):
+            split_name = split_file.stem
+            with split_file.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    rel = line.strip()
+                    if rel and rel not in data_paths:
+                        logger.error("Split %s references missing model %s", split_name, rel)
+                        missing += 1
+        lmdb_path = root / "lmdb"
+        if lmdb_path.exists():
+            import lmdb
+            env = lmdb.open(str(lmdb_path), readonly=True, lock=False)
+            with env.begin() as txn:
+                for rel in data_paths:
+                    key = f"object/{rel}".encode("utf-8")
+                    val = txn.get(key)
+                    if val is None:
+                        logger.error("LMDB missing key %s", key.decode())
+                        missing += 1
+            env.close()
+        if missing:
+            raise SystemExit(1)
+        logger.info("Validation passed")
+
+
+__all__ = ["ShapeNetProfile"]
+

--- a/pcdset/utils/taxonomy.py
+++ b/pcdset/utils/taxonomy.py
@@ -1,0 +1,97 @@
+"""Taxonomy helper utilities.
+
+This module provides small helpers used by the ShapeNet profile to build and
+persist taxonomy files.  A taxonomy maps a category *synset* to a human readable
+label.  Two file formats are supported: CSV and JSON.  CSV files are expected to
+contain two columns named ``synset`` and ``label``.
+
+The functions are intentionally lightweight and do not depend on external
+libraries so they can be used in small conversion scripts as well.
+
+Examples
+--------
+>>> from pathlib import Path
+>>> save_taxonomy({'03001627': 'chair'}, Path('tax.csv'))
+>>> load_taxonomy(Path('tax.csv'))['03001627']
+'chair'
+"""
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Dict, Iterable
+
+
+def load_taxonomy(path: Path) -> Dict[str, str]:
+    """Load a taxonomy mapping from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Input file path.  The format is derived from the file extension.
+    """
+
+    if path.suffix.lower() == ".json":
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    mapping: Dict[str, str] = {}
+    with path.open("r", newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            mapping[row["synset"].strip()] = row.get("label", "").strip()
+    return mapping
+
+
+def save_taxonomy(taxonomy: Dict[str, str], path: Path) -> None:
+    """Persist ``taxonomy`` to ``path``.
+
+    ``path`` may end in ``.json`` or ``.csv``.  Parent directories are created
+    automatically.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.suffix.lower() == ".json":
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(taxonomy, fh, indent=2, sort_keys=True)
+        return
+
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["synset", "label"])
+        for syn, label in taxonomy.items():
+            writer.writerow([syn, label])
+
+
+def build_taxonomy(categories: Iterable[str]) -> Dict[str, str]:
+    """Create a simple taxonomy mapping from *categories*.
+
+    The returned dictionary maps each category to itself.  It can later be
+    modified manually to include human readable labels or synset ids.
+    """
+
+    return {c: c for c in sorted(set(categories))}
+
+
+def load_category_map(path: Path) -> Dict[str, str]:
+    """Load a category remapping CSV file.
+
+    The CSV must contain two columns named ``src`` and ``dst``.  This function
+    is shared between the PCN and ShapeNet profiles.
+    """
+
+    mapping: Dict[str, str] = {}
+    with path.open("r", newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            mapping[row["src"].strip()] = row["dst"].strip()
+    return mapping
+
+
+__all__ = [
+    "load_taxonomy",
+    "save_taxonomy",
+    "build_taxonomy",
+    "load_category_map",
+]
+


### PR DESCRIPTION
## Summary
- add ShapeNetProfile to convert point clouds into ShapeNet-style datasets and LMDB
- introduce taxonomy helpers and category mapping utilities
- extend CLI/README to expose new shapenet profile and NPZ/PCD writers

## Testing
- `python -m pcdset.main list-profiles`
- `python -m pcdset.main example-manifest --profile shapenet -o manifest.csv`
- `python -m pcdset.main convert --profile shapenet --input raw --out out_shapenet_ply --workers 1`
- `python -m pcdset.main validate --profile shapenet --root out_shapenet_ply`


------
https://chatgpt.com/codex/tasks/task_e_68c436ea98f08325a3b60ad041d03e96